### PR TITLE
Add percentage chip to account cards

### DIFF
--- a/backend/src/jenmoney/schemas/account.py
+++ b/backend/src/jenmoney/schemas/account.py
@@ -42,6 +42,7 @@ class AccountResponse(AccountBase):
 
     id: int
     balance: float
+    percentage_of_total: float | None = None
     balance_in_default_currency: float | None = None
     default_currency: Currency | None = None
     exchange_rate_used: float | None = None

--- a/backend/src/jenmoney/services/account_analytics_service.py
+++ b/backend/src/jenmoney/services/account_analytics_service.py
@@ -1,0 +1,39 @@
+from decimal import Decimal
+from typing import cast
+from sqlalchemy.orm import Session
+
+from jenmoney.models.account import Account
+from jenmoney.services.currency_service import CurrencyService
+
+
+class AccountAnalyticService:
+    """Service for handling analytics for accounts"""
+
+    def get_account_percentage(self, db: Session, account_id: int) -> float:
+        currency_service: CurrencyService = CurrencyService(db)
+        accounts: list[Account] = db.query(Account).all()
+        if not accounts:
+            return 0.0
+
+        total_usd: Decimal = Decimal("0")
+        target_usd: Decimal | None = None
+
+        for acc in accounts:
+            # Cast because SQLAlchemy attribute is typed as Column[Decimal] for Pylance
+            usd_amount = Decimal(
+                str(
+                    currency_service.convert_amount(
+                        amount=cast(Decimal, acc.balance),
+                        from_currency=cast(str, acc.currency),
+                        to_currency="USD",
+                    )
+                )
+            )
+            total_usd += usd_amount
+            if cast(int, acc.id) == account_id:
+                target_usd = usd_amount
+
+        if total_usd == 0 or target_usd is None:
+            return 0.0
+
+        return float(round(target_usd / total_usd, 2))

--- a/backend/tests/api/v1/test_accounts_percentage.py
+++ b/backend/tests/api/v1/test_accounts_percentage.py
@@ -1,0 +1,205 @@
+from fastapi.testclient import TestClient
+
+from jenmoney.models.currency_rate import CurrencyRate
+from jenmoney.database import get_db
+from datetime import datetime, timezone
+from decimal import Decimal
+
+
+class TestAccountPercentage:
+    def test_single_account_percentage(self, client: TestClient):
+        """Test that a single account shows 100% of total"""
+        # Create single account
+        payload = {"name": "Only Account", "currency": "USD", "balance": 1000.00}
+        response = client.post("/api/v1/accounts/", json=payload)
+        account_id = response.json()["id"]
+
+        # Get account with percentage
+        response = client.get(f"/api/v1/accounts/{account_id}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["percentage_of_total"] == 1.0  # 100%
+
+    def test_multiple_accounts_equal_percentage(self, client: TestClient):
+        """Test equal distribution among accounts with same balance"""
+        # Create 4 accounts with equal balance
+        accounts = []
+        for i in range(4):
+            payload = {"name": f"Account {i + 1}", "currency": "USD", "balance": 250.00}
+            response = client.post("/api/v1/accounts/", json=payload)
+            accounts.append(response.json()["id"])
+
+        # Check each account has 25%
+        for account_id in accounts:
+            response = client.get(f"/api/v1/accounts/{account_id}")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["percentage_of_total"] == 0.25  # 25%
+
+    def test_accounts_list_includes_percentage(self, client: TestClient):
+        """Test that account list endpoint includes percentage for each account"""
+        # Create accounts with different balances
+        accounts_data = [
+            {"name": "Account 1", "currency": "USD", "balance": 600.00},
+            {"name": "Account 2", "currency": "USD", "balance": 300.00},
+            {"name": "Account 3", "currency": "USD", "balance": 100.00},
+        ]
+
+        for account_data in accounts_data:
+            client.post("/api/v1/accounts/", json=account_data)
+
+        # Get accounts list
+        response = client.get("/api/v1/accounts/")
+        assert response.status_code == 200
+        data = response.json()
+
+        # Sort items by balance for predictable testing
+        items = sorted(data["items"], key=lambda x: x["balance"], reverse=True)
+
+        # Check percentages (600/1000=0.6, 300/1000=0.3, 100/1000=0.1)
+        assert items[0]["percentage_of_total"] == 0.6  # 60%
+        assert items[1]["percentage_of_total"] == 0.3  # 30%
+        assert items[2]["percentage_of_total"] == 0.1  # 10%
+
+    def test_zero_balance_account_percentage(self, client: TestClient):
+        """Test that account with zero balance shows 0%"""
+        # Create accounts
+        client.post(
+            "/api/v1/accounts/",
+            json={"name": "Rich Account", "currency": "USD", "balance": 1000.00},
+        )
+        response = client.post(
+            "/api/v1/accounts/", json={"name": "Empty Account", "currency": "USD", "balance": 0.00}
+        )
+        empty_account_id = response.json()["id"]
+
+        # Check empty account has 0%
+        response = client.get(f"/api/v1/accounts/{empty_account_id}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["percentage_of_total"] == 0.0  # 0%
+
+    def test_percentage_with_different_currencies(self, client: TestClient):
+        """Test percentage calculation with multiple currencies"""
+        # First, we need to set up exchange rates
+        # Get a database session to add exchange rates
+        from jenmoney.main import app
+
+        test_db = next(app.dependency_overrides[get_db]())
+
+        # Add exchange rates (all to USD)
+        rates = [
+            CurrencyRate(
+                currency_from="EUR",
+                currency_to="USD",
+                rate=Decimal("1.1"),  # 1 EUR = 1.1 USD
+                effective_from=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            ),
+            CurrencyRate(
+                currency_from="JPY",
+                currency_to="USD",
+                rate=Decimal("0.0067"),  # 1 JPY = 0.0067 USD
+                effective_from=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            ),
+        ]
+        for rate in rates:
+            test_db.add(rate)
+        test_db.commit()
+
+        # Create accounts with different currencies
+        accounts_data = [
+            {"name": "USD Account", "currency": "USD", "balance": 1000.00},  # $1000
+            {"name": "EUR Account", "currency": "EUR", "balance": 909.09},  # ~$1000 (909.09 * 1.1)
+            {
+                "name": "JPY Account",
+                "currency": "JPY",
+                "balance": 149253.73,
+            },  # ~$1000 (149253.73 * 0.0067)
+        ]
+
+        account_ids = []
+        for account_data in accounts_data:
+            response = client.post("/api/v1/accounts/", json=account_data)
+            account_ids.append(response.json()["id"])
+
+        # Each account should be approximately 33.33% (1/3)
+        for account_id in account_ids:
+            response = client.get(f"/api/v1/accounts/{account_id}")
+            assert response.status_code == 200
+            data = response.json()
+            # Allow some tolerance for floating point calculations
+            assert 0.32 <= data["percentage_of_total"] <= 0.34
+
+        test_db.close()
+
+    def test_percentage_updates_after_balance_change(self, client: TestClient):
+        """Test that percentage is recalculated after account balance update"""
+        # Create two accounts
+        response1 = client.post(
+            "/api/v1/accounts/", json={"name": "Account 1", "currency": "USD", "balance": 500.00}
+        )
+        account1_id = response1.json()["id"]
+
+        response2 = client.post(
+            "/api/v1/accounts/", json={"name": "Account 2", "currency": "USD", "balance": 500.00}
+        )
+        account2_id = response2.json()["id"]
+
+        # Initially both should be 50%
+        response = client.get(f"/api/v1/accounts/{account1_id}")
+        assert response.json()["percentage_of_total"] == 0.5
+
+        # Update account1 balance
+        client.patch(f"/api/v1/accounts/{account1_id}", json={"balance": 1500.00})
+
+        # Now account1 should be 75% (1500/2000)
+        response = client.get(f"/api/v1/accounts/{account1_id}")
+        assert response.json()["percentage_of_total"] == 0.75
+
+        # And account2 should be 25% (500/2000)
+        response = client.get(f"/api/v1/accounts/{account2_id}")
+        assert response.json()["percentage_of_total"] == 0.25
+
+    def test_percentage_after_account_deletion(self, client: TestClient):
+        """Test that percentages are recalculated after account deletion"""
+        # Create three accounts
+        accounts = []
+        for i in range(3):
+            response = client.post(
+                "/api/v1/accounts/",
+                json={"name": f"Account {i + 1}", "currency": "USD", "balance": 100.00},
+            )
+            accounts.append(response.json()["id"])
+
+        # Initially each should be ~33.33%
+        response = client.get(f"/api/v1/accounts/{accounts[0]}")
+        assert abs(response.json()["percentage_of_total"] - 0.33) < 0.01
+
+        # Delete one account
+        client.delete(f"/api/v1/accounts/{accounts[2]}")
+
+        # Remaining accounts should now be 50% each
+        for account_id in accounts[:2]:
+            response = client.get(f"/api/v1/accounts/{account_id}")
+            assert response.json()["percentage_of_total"] == 0.5
+
+    def test_percentage_rounding(self, client: TestClient):
+        """Test that percentages are properly rounded"""
+        # Create accounts that will result in repeating decimals
+        accounts_data = [
+            {"name": "Account 1", "currency": "USD", "balance": 100.00},
+            {"name": "Account 2", "currency": "USD", "balance": 200.00},
+        ]
+
+        account_ids = []
+        for account_data in accounts_data:
+            response = client.post("/api/v1/accounts/", json=account_data)
+            account_ids.append(response.json()["id"])
+
+        # Check first account (100/300 = 0.333... should be 0.33)
+        response = client.get(f"/api/v1/accounts/{account_ids[0]}")
+        assert response.json()["percentage_of_total"] == 0.33
+
+        # Check second account (200/300 = 0.666... should be 0.67)
+        response = client.get(f"/api/v1/accounts/{account_ids[1]}")
+        assert response.json()["percentage_of_total"] == 0.67

--- a/backend/tests/services/test_account_analytics_service.py
+++ b/backend/tests/services/test_account_analytics_service.py
@@ -1,0 +1,248 @@
+from decimal import Decimal
+from unittest.mock import Mock, patch
+
+from sqlalchemy.orm import Session
+
+from jenmoney.models.account import Account
+from jenmoney.services.account_analytics_service import AccountAnalyticService
+
+
+class TestAccountAnalyticService:
+    def test_get_account_percentage_single_account(self):
+        """Test percentage calculation with a single account (should be 100%)"""
+        db = Mock(spec=Session)
+        service = AccountAnalyticService()
+
+        # Create mock account
+        account = Mock(spec=Account)
+        account.id = 1
+        account.balance = Decimal("1000.00")
+        account.currency = "USD"
+
+        # Mock database query
+        db.query.return_value.all.return_value = [account]
+
+        # Mock currency service to return same value (USD to USD)
+        with patch(
+            "jenmoney.services.account_analytics_service.CurrencyService"
+        ) as MockCurrencyService:
+            mock_currency_service = MockCurrencyService.return_value
+            mock_currency_service.convert_amount.return_value = Decimal("1000.00")
+
+            result = service.get_account_percentage(db, 1)
+
+            # Single account should be 100%
+            assert result == 1.0
+
+    def test_get_account_percentage_multiple_accounts_equal(self):
+        """Test percentage calculation with multiple accounts of equal value"""
+        db = Mock(spec=Session)
+        service = AccountAnalyticService()
+
+        # Create mock accounts
+        accounts = []
+        for i in range(4):
+            account = Mock(spec=Account)
+            account.id = i + 1
+            account.balance = Decimal("250.00")
+            account.currency = "USD"
+            accounts.append(account)
+
+        # Mock database query
+        db.query.return_value.all.return_value = accounts
+
+        # Mock currency service
+        with patch(
+            "jenmoney.services.account_analytics_service.CurrencyService"
+        ) as MockCurrencyService:
+            mock_currency_service = MockCurrencyService.return_value
+            mock_currency_service.convert_amount.return_value = Decimal("250.00")
+
+            result = service.get_account_percentage(db, 2)
+
+            # Each account should be 25%
+            assert result == 0.25
+
+    def test_get_account_percentage_different_currencies(self):
+        """Test percentage calculation with different currencies"""
+        db = Mock(spec=Session)
+        service = AccountAnalyticService()
+
+        # Create mock accounts with different currencies
+        account1 = Mock(spec=Account)
+        account1.id = 1
+        account1.balance = Decimal("1000.00")
+        account1.currency = "EUR"
+
+        account2 = Mock(spec=Account)
+        account2.id = 2
+        account2.balance = Decimal("500.00")
+        account2.currency = "USD"
+
+        account3 = Mock(spec=Account)
+        account3.id = 3
+        account3.balance = Decimal("100000.00")
+        account3.currency = "JPY"
+
+        # Mock database query
+        db.query.return_value.all.return_value = [account1, account2, account3]
+
+        # Mock currency service with realistic exchange rates
+        with patch(
+            "jenmoney.services.account_analytics_service.CurrencyService"
+        ) as MockCurrencyService:
+            mock_currency_service = MockCurrencyService.return_value
+
+            def convert_side_effect(amount, from_currency, to_currency):
+                if from_currency == "EUR":
+                    return Decimal("1100.00")  # 1 EUR = 1.1 USD
+                elif from_currency == "USD":
+                    return Decimal("500.00")
+                elif from_currency == "JPY":
+                    return Decimal("900.00")  # 100000 JPY = 900 USD
+                return amount
+
+            mock_currency_service.convert_amount.side_effect = convert_side_effect
+
+            result = service.get_account_percentage(db, 2)
+
+            # Account 2: 500 USD out of (1100 + 500 + 900) = 500/2500 = 0.20
+            assert result == 0.20
+
+    def test_get_account_percentage_zero_balance(self):
+        """Test percentage calculation when account has zero balance"""
+        db = Mock(spec=Session)
+        service = AccountAnalyticService()
+
+        # Create mock accounts
+        account1 = Mock(spec=Account)
+        account1.id = 1
+        account1.balance = Decimal("1000.00")
+        account1.currency = "USD"
+
+        account2 = Mock(spec=Account)
+        account2.id = 2
+        account2.balance = Decimal("0.00")
+        account2.currency = "USD"
+
+        # Mock database query
+        db.query.return_value.all.return_value = [account1, account2]
+
+        # Mock currency service
+        with patch(
+            "jenmoney.services.account_analytics_service.CurrencyService"
+        ) as MockCurrencyService:
+            mock_currency_service = MockCurrencyService.return_value
+
+            def convert_side_effect(amount, from_currency, to_currency):
+                return amount
+
+            mock_currency_service.convert_amount.side_effect = convert_side_effect
+
+            result = service.get_account_percentage(db, 2)
+
+            # Account with zero balance should be 0%
+            assert result == 0.0
+
+    def test_get_account_percentage_nonexistent_account(self):
+        """Test percentage calculation for non-existent account"""
+        db = Mock(spec=Session)
+        service = AccountAnalyticService()
+
+        # Create mock account
+        account = Mock(spec=Account)
+        account.id = 1
+        account.balance = Decimal("1000.00")
+        account.currency = "USD"
+
+        # Mock database query
+        db.query.return_value.all.return_value = [account]
+
+        # Mock currency service
+        with patch(
+            "jenmoney.services.account_analytics_service.CurrencyService"
+        ) as MockCurrencyService:
+            mock_currency_service = MockCurrencyService.return_value
+            mock_currency_service.convert_amount.return_value = Decimal("1000.00")
+
+            result = service.get_account_percentage(db, 999)  # Non-existent ID
+
+            # Non-existent account should return 0%
+            assert result == 0.0
+
+    def test_get_account_percentage_no_accounts(self):
+        """Test percentage calculation when no accounts exist"""
+        db = Mock(spec=Session)
+        service = AccountAnalyticService()
+
+        # Mock database query returning empty list
+        db.query.return_value.all.return_value = []
+
+        result = service.get_account_percentage(db, 1)
+
+        # Should return 0% when no accounts exist
+        assert result == 0.0
+
+    def test_get_account_percentage_all_zero_balances(self):
+        """Test percentage calculation when all accounts have zero balance"""
+        db = Mock(spec=Session)
+        service = AccountAnalyticService()
+
+        # Create mock accounts with zero balances
+        accounts = []
+        for i in range(3):
+            account = Mock(spec=Account)
+            account.id = i + 1
+            account.balance = Decimal("0.00")
+            account.currency = "USD"
+            accounts.append(account)
+
+        # Mock database query
+        db.query.return_value.all.return_value = accounts
+
+        # Mock currency service
+        with patch(
+            "jenmoney.services.account_analytics_service.CurrencyService"
+        ) as MockCurrencyService:
+            mock_currency_service = MockCurrencyService.return_value
+            mock_currency_service.convert_amount.return_value = Decimal("0.00")
+
+            result = service.get_account_percentage(db, 1)
+
+            # Should return 0% when all balances are zero
+            assert result == 0.0
+
+    def test_get_account_percentage_rounding(self):
+        """Test that percentage is properly rounded to 2 decimal places"""
+        db = Mock(spec=Session)
+        service = AccountAnalyticService()
+
+        # Create mock accounts that will result in repeating decimal
+        account1 = Mock(spec=Account)
+        account1.id = 1
+        account1.balance = Decimal("100.00")
+        account1.currency = "USD"
+
+        account2 = Mock(spec=Account)
+        account2.id = 2
+        account2.balance = Decimal("200.00")
+        account2.currency = "USD"
+
+        # Mock database query
+        db.query.return_value.all.return_value = [account1, account2]
+
+        # Mock currency service
+        with patch(
+            "jenmoney.services.account_analytics_service.CurrencyService"
+        ) as MockCurrencyService:
+            mock_currency_service = MockCurrencyService.return_value
+
+            def convert_side_effect(amount, from_currency, to_currency):
+                return amount
+
+            mock_currency_service.convert_amount.side_effect = convert_side_effect
+
+            result = service.get_account_percentage(db, 1)
+
+            # 100/300 = 0.333... should be rounded to 0.33
+            assert result == 0.33

--- a/frontend/src/components/AccountCard.tsx
+++ b/frontend/src/components/AccountCard.tsx
@@ -70,18 +70,27 @@ export const AccountCard: React.FC<AccountCardProps> = ({
               overflow: 'hidden',
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap',
-              maxWidth: '70%',
+              maxWidth: '50%',
             }}
           >
             {account.name}
           </Typography>
-          <Chip
-            label={account.currency}
-            size="small"
-            color="primary"
-            variant="outlined"
-            sx={{ fontWeight: 600 }}
-          />
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            <Chip
+              label={account.currency}
+              size="small"
+              color="primary"
+              variant="outlined"
+              sx={{ fontWeight: 600 }}
+            />
+            <Chip
+              label={`${(account.percentage_of_total * 100).toFixed(0)}%`}
+              size="small"
+              color="default"
+              variant="outlined"
+              sx={{ fontWeight: 600 }}
+            />
+          </Box>
         </Box>
 
         <Typography

--- a/frontend/src/types/account.ts
+++ b/frontend/src/types/account.ts
@@ -13,6 +13,7 @@ export interface Account {
   currency: Currency;
   balance: number;
   balance_in_default_currency?: number | null;
+  percentage_of_total: number;
   default_currency?: Currency | null;
   exchange_rate_used?: number | null;
   description?: string | null;


### PR DESCRIPTION
## Summary
- Added percentage chip showing each account's portion of total portfolio
- Displays next to currency chip in format [USD] [71%]
- Uses existing percentage_of_total field from API

## Test plan
- [x] Verify percentage chips display correctly on all account cards
- [x] Check that percentages update when account balances change
- [x] Ensure proper layout on different screen sizes